### PR TITLE
sync boost command to next version of esp-tion

### DIFF
--- a/tion-esp-esptemp.json
+++ b/tion-esp-esptemp.json
@@ -116,11 +116,11 @@
           "type": "On",
           "link": {
             "type": "String",
-            "topicGet": "(1)/climate/(2)/preset/state",
-            "topicSet": "(1)/climate/(2)/preset/command",
+            "topicGet": "(1)/switch/boost/state",
+            "topicSet": "(1)/switch/boost/command",
             "map": {
-              "false": "none",
-              "true": "boost"
+                "false": "OFF",
+                "true": "ON"
             }
           }
         }

--- a/tion-esp.json
+++ b/tion-esp.json
@@ -116,11 +116,11 @@
           "type": "On",
           "link": {
             "type": "String",
-            "topicGet": "(1)/climate/(2)/preset/state",
-            "topicSet": "(1)/climate/(2)/preset/command",
+            "topicGet": "(1)/switch/boost/state",
+            "topicSet": "(1)/switch/boost/command",
             "map": {
-              "false": "none",
-              "true": "boost"
+                "false": "OFF",
+                "true": "ON"
             }
           }
         }


### PR DESCRIPTION
В next-ветке esphome-tion поменялся формат для чтения/включения турбо-режима.

Было бы удобно в репозитории с шаблоном тоже завести вторую ветку (next), чтобы иметь возможность поддерживать там актуальный шаблон для бета-версии.

Денис сказал что готов поддерживать разные ссылки в README для разных веток.
https://t.me/esphome_tion/11589


Собственно предлагаю сделать ветку next и этот PR влить уже туда (т.к. с релизной версией прошивки этот вариант работать уже не будет).